### PR TITLE
Fixed preview playbacks

### DIFF
--- a/src/SpotifyPlayer.jsx
+++ b/src/SpotifyPlayer.jsx
@@ -51,6 +51,7 @@ class SpotifyPlayer extends Component {
         height={size.height}
         frameBorder="0"
         allowtransparency="true"
+        allow="encrypted-media"
       />
     );
   }


### PR DESCRIPTION
Allowed encrypted media to make the component fully functional with no playback restrictions, see deprecation at: https://sites.google.com/a/chromium.org/dev/Home/chromium-security/deprecating-permissions-in-cross-origin-iframes. Without change, playback is limited to short, 20 second clips for each track instead of the intended full playback.